### PR TITLE
ignore sqlite files

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -20,5 +20,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# data storage
-db/storage
+# data storage files
+db/storage/*.sqlite


### PR DESCRIPTION
also keep the `/storage` directory alive with an empty `.keep` file because sequelize needs that directory for migrations